### PR TITLE
Don’t continue if a command fails

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,16 +6,16 @@ generate_font() {
 
   svgs_dir="svgs"
 
-  mkdir ${tbd_dir}
+  mkdir ${tbd_dir} || exit
 
-  gulp --font ${font_name}
-  rm -f tmp/${font_name}/{*.eot,*.svg,*.woff}
+  gulp --font ${font_name} || exit
+  rm -f tmp/${font_name}/{*.eot,*.svg,*.woff} || exit
 
-  python generate_json.py ${font_name}
+  python generate_json.py ${font_name} || exit
 
 
   #Dumping 'cmap' table
-  ttx -o tmp/${font_name}/${font_name}.ttx -t cmap tmp/${font_name}/${font_name}.ttf
+  ttx -o tmp/${font_name}/${font_name}.ttx -t cmap tmp/${font_name}/${font_name}.ttf || exit
 
   # Remove Glyphs from 'cmap' table
   for file in `find ${svgs_dir}/${font_name}/ -name "*.svg"`
@@ -25,47 +25,47 @@ generate_font() {
       if [[ $filename == *layer* ]]
         then
           code=${filename%.*}
-          sed /$code/d tmp/${font_name}/${font_name}.ttx > tmp/${font_name}/output.tmp
-          mv tmp/${font_name}/output.tmp tmp/${font_name}/${font_name}.ttx
+          sed /$code/d tmp/${font_name}/${font_name}.ttx > tmp/${font_name}/output.tmp || exit
+          mv tmp/${font_name}/output.tmp tmp/${font_name}/${font_name}.ttx || exit
       fi
 
       # if [[ $filename == *flag* ]]
       #   then
       #     code=${filename%.*}
-      #     sed /$code/d tmp/${font_name}/${font_name}.ttx > tmp/${font_name}/output.tmp
-      #     mv tmp/${font_name}/output.tmp tmp/${font_name}/${font_name}.ttx
+      #     sed /$code/d tmp/${font_name}/${font_name}.ttx > tmp/${font_name}/output.tmp || exit
+      #     mv tmp/${font_name}/output.tmp tmp/${font_name}/${font_name}.ttx || exit
       # fi
   done
 
   #Merge 'cmap' table back to font
-  ttx -o tmp/${font_name}/${font_name}-cmap.ttf -m tmp/${font_name}/${font_name}.ttf tmp/${font_name}/${font_name}.ttx
+  ttx -o tmp/${font_name}/${font_name}-cmap.ttf -m tmp/${font_name}/${font_name}.ttf tmp/${font_name}/${font_name}.ttx || exit
 
-  python generate_colr_ttx_from_json.py ${font_name}.json templates/colr.ttx tmp/${font_name}/${font_name}-colr.ttx
+  python generate_colr_ttx_from_json.py ${font_name}.json templates/colr.ttx tmp/${font_name}/${font_name}-colr.ttx || exit
 
 
   #Merge 'COLR' table to font
-  ttx -o tmp/${font_name}/${font_name}-colr.ttf -m tmp/${font_name}/${font_name}-cmap.ttf tmp/${font_name}/${font_name}-colr.ttx
+  ttx -o tmp/${font_name}/${font_name}-colr.ttf -m tmp/${font_name}/${font_name}-cmap.ttf tmp/${font_name}/${font_name}-colr.ttx || exit
 
 
 
   if [[ ${font_name} == 'FirefoxEmoji' || ${font_name} == 'flags' ]]
     then
       #Merge 'GSUB' table to font
-      ttx -o tmp/${font_name}/${font_name}-gsub.ttf -m tmp/${font_name}/${font_name}-colr.ttf templates/gsub.ttx
+      ttx -o tmp/${font_name}/${font_name}-gsub.ttf -m tmp/${font_name}/${font_name}-colr.ttf templates/gsub.ttx || exit
 
       #move final font to 'dist' folder
-      mv tmp/${font_name}/${font_name}-gsub.ttf dist/${font_name}/${font_name}.ttf
+      mv tmp/${font_name}/${font_name}-gsub.ttf dist/${font_name}/${font_name}.ttf || exit
     else
       #move final font to 'dist' folder
-      mv tmp/${font_name}/${font_name}-colr.ttf dist/${font_name}/${font_name}.ttf
+      mv tmp/${font_name}/${font_name}-colr.ttf dist/${font_name}/${font_name}.ttf || exit
 
   fi
 
   if [[ ${font_name} == 'FirefoxEmoji' ]]
     then
-    mv dist/${font_name}/${font_name}.ttf dist/${font_name}/${font_name}-tmp.ttf
-    ttx -o dist/${font_name}/${font_name}.ttf -m dist/${font_name}/${font_name}-tmp.ttf templates/name.ttx
-    rm dist/${font_name}/${font_name}-tmp.ttf
+    mv dist/${font_name}/${font_name}.ttf dist/${font_name}/${font_name}-tmp.ttf || exit
+    ttx -o dist/${font_name}/${font_name}.ttf -m dist/${font_name}/${font_name}-tmp.ttf templates/name.ttx || exit
+    rm dist/${font_name}/${font_name}-tmp.ttf || exit
   fi
 
   clean "tmp"
@@ -73,7 +73,7 @@ generate_font() {
 
 #Clean tmp
 clean() {
-  rm -rf ${1}
+  rm -rf ${1} || exit
 }
 
 clean tbd


### PR DESCRIPTION
Makes it clear which command is failing, instead of masking it with
hundreds of errors from subsequent commands that depend on the success
of previous ones.
