### PR TITLE
Support building with Python 3

### DIFF
--- a/check_images.py
+++ b/check_images.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 import json
@@ -6,7 +8,7 @@ import shutil
 if __name__ == "__main__":
 
   if len(sys.argv)<1:
-    print "Please provide arguments."
+    print("Please provide arguments.")
     sys.exit(1)
 
   font_name=sys.argv[1]

--- a/generate_colr_ttx_from_json.py
+++ b/generate_colr_ttx_from_json.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import json
 from lxml import etree
@@ -5,7 +7,7 @@ from lxml import etree
 if __name__ == "__main__":
 
   if len(sys.argv)<3:
-    print "Please provide arguments."
+    print("Please provide arguments.")
     sys.exit(1)
 
   json_file=sys.argv[1]
@@ -55,6 +57,9 @@ if __name__ == "__main__":
 
 
   xml = etree.tostring(tree)
+  if not isinstance(xml, str):
+      xml = xml.decode("utf-8")
+
   f=open(output_file,'w+')
   f.write('<?xml version="1.0" encoding="utf-8"?>\n')
   f.write(xml)

--- a/generate_json.py
+++ b/generate_json.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 import natsort
@@ -7,7 +9,7 @@ import json
 if __name__ == "__main__":
 
   if len(sys.argv)<1:
-    print "Please provide arguments."
+    print("Please provide arguments.")
     sys.exit(1)
 
   font_name=sys.argv[1]


### PR DESCRIPTION
Some Linux distros has Python 3 binary as just `python`, as absurd as
this can be, but it seems easy to make the Python scripts here run under
both.
