### PR TITLE
Remove spaces from PostScript name

### DIFF
--- a/templates/name.ttx
+++ b/templates/name.ttx
@@ -17,7 +17,7 @@
       Version 1.7.2
     </namerecord>
     <namerecord nameID="6" platformID="1" platEncID="0" langID="0x0">
-      Firefox Emoji
+      FirefoxEmoji
     </namerecord>
     <namerecord nameID="10" platformID="1" platEncID="0" langID="0x0"></namerecord>
     <namerecord nameID="11" platformID="1" platEncID="0" langID="0x0"></namerecord>
@@ -37,7 +37,7 @@
       Version 1.7.2
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
-      Firefox Emoji
+      FirefoxEmoji
     </namerecord>
     <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409"></namerecord>
     <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409"></namerecord>


### PR DESCRIPTION
Spaces are not allowed in PostScript name (name ID 6), see it entry in:
http://www.microsoft.com/typography/otspec/name.htm
