### PR TITLE
Fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#FxEmojis
+# FxEmojis
 http://mozilla.github.io/fxemoji/
 
 Formerly the Firefox OS emoji set, now just FxEmojis. 
 
-##Requirements
+## Requirements
 
 * bash
 * TTX/FontTools - please use https://github.com/behdad/fonttools/
@@ -30,19 +30,19 @@ We need few SVG's per icon.
 
 The files need to be named with uni code prefix.
 
-###First Icon :
+### First Icon :
 - u1F60A-smileeyes.svg (complete glyph)
 - u1F60A.layer1.svg (Layer 1)
 - u1F60A.layer2.svg (Layer 2)
 - etc.
 
-###Second Icon :
+### Second Icon :
 - u1F60B-smiletongue.svg (complete glyph)
 - u1F60B.layer1.svg (Layer 1)
 - u1F60B.layer2.svg (Layer 2)
 - etc.
 
-##How to Contribute
+## How to Contribute
 
 Please contact Mike Hoye (mhoye@mozilla.com) for contribution information; more info TBD. 
 


### PR DESCRIPTION
Some markdown in README.md would not render properly as there was no space in between the # or ## and the actual heading, this has been fixed